### PR TITLE
Shadow `\maketitle` with `\coverpage` by default

### DIFF
--- a/dsekdoc.cls
+++ b/dsekdoc.cls
@@ -16,6 +16,11 @@
 \PassOptionsToClass{11pt}{article}
 \DeclareOption*{\PassOptionsToClass{\CurrentOption}{article}}
 
+\bool_new:N \g_dsekdoc_shadow_maketitle_bool
+\bool_set_true:N \g_dsek_shadow_maketitle_bool
+
+\DeclareOption{maketitle}{\bool_set_false:N \g_dsek_in_color_bool}
+
 \ExplSyntaxOff
 
 %% Execution of options
@@ -176,6 +181,10 @@
       \Dseksigil[color, height=70mm]
     \end{center}
   \end{titlepage}
+}
+
+\bool_if:NT \g_dsek_shadow_maketitle_bool {
+  \RenewDocumentCommand \maketitle {} { \coverpage }
 }
 
 %% Headers and footers

--- a/dsekdocs.tex
+++ b/dsekdocs.tex
@@ -183,10 +183,14 @@ documents for which the standard style is desired.  It is based of the
 and footers amongst a few other things.
 
 \subsection{Options}
-The \textsf{dsekdoc} document only declares one special option,
-\texttt{english}, which tells the language package \textsf{polyglossia} that the
-main language for the document is English instead of Swedish.  All other
-arguments are passed along to the \textsf{article} document class.
+The \textsf{dsekdoc} document declares two special options:
+\begin{description}
+\item[\texttt{maketitle}] makes \textsf{dsekdoc} not redefine the \cs{maketitle}
+  command (use the \cs{coverpage} command instead).
+\item[\texttt{english}] tells the language package \textsf{polyglossia} that
+  the main language for the document is English instead of Swedish.
+\end{description}
+All other arguments are passed through to the \textsf{article} document class.
 
 \subsection{Commands}
 Because of how the \cs{title}, \cs{author} and \cs{date} commands work, we can't
@@ -210,10 +214,10 @@ for or when it was established.  Those are set with
 
 \subsubsection{Cover page}
 For longer, more important documents it is nice to have a cover page for the
-document.  To insert one, use
+document.  By default, the cover page is inserted with
 
 \begin{center}
-  \cs{coverpage}
+  \cs{maketitle} or \cs{coverpage}
 \end{center}
 
 In addition to the guild's name, the guild's sigil and the title of the


### PR DESCRIPTION
The shadowing can be disabled by passing the option `maketitle` to the dsekdoc document class.

This pull request is a draft as it lacks proper tests. 