### PR TITLE
Add counter to attlist

### DIFF
--- a/dsek.sty
+++ b/dsek.sty
@@ -112,9 +112,15 @@
 }
 
 \NewDocumentEnvironment{attlist}{} {
-  \begin{boldlist}{att}
+  \ifcsname c@rownumbers \endcsname % If the counter exists, don't create it
+    \begin{boldlist}{\textnormal{(\stepcounter{rownumbers}\arabic{rownumbers})} \quad att}
+  \else
+  \newcounter{rownumbers} % Create the counter
+  \begin{boldlist}{\textnormal{(\stepcounter{rownumbers}\arabic{rownumbers})} \quad att}
+  \fi
 } {
   \end{boldlist}
+  \setcounter{rownumbers}{0} % Reset the counter when done with the list
 }
 
 %% Signatures


### PR DESCRIPTION
These changes adds a counter to the attlist, so that an attlist looks like
(1)   **att** sjunga mer
(2)  **att** sjunga ännu mer

This could come in handy when an attlist is very long :)

The spacing on the counter could be tweaked