### PR TITLE
Add motion/proposition document class

### DIFF
--- a/dsekmotion.cls
+++ b/dsekmotion.cls
@@ -29,15 +29,6 @@
     }
 }
 
-\NewDocumentCommand \setdemand { m } {
-    \tl_set:Nn \g_demand_tl { #1 }
-}
-
-\NewDocumentCommand \usedemand {} {
-    \vspace{0.5cm}
-    \tl_use:N \g_demand_tl
-}
-
 %% Handy commands to be used in att-lists
 \NewDocumentCommand \att { m } {
   \item #1

--- a/dsekmotion.cls
+++ b/dsekmotion.cls
@@ -1,0 +1,50 @@
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesClass{dsekmotion}[2023/10/14]
+\RequirePackage{expl3}
+
+\ExplSyntaxOn
+
+%% Declaration of options, default to motion
+\DeclareOption{motion}{\bool_set_true:N \g_dsek_motion_bool}
+\DeclareOption{proposition}{\bool_set_false:N \g_dsek_motion_bool}
+\bool_set_true:N \g_dsek_motion_bool
+
+\ProcessOptions \relax
+
+\LoadClass{dsekdoc}
+
+%% If motion, set title to Motion, else set to Proposition
+%% Also create create a section with the title
+\bool_if:NTF \g_dsek_motion_bool {
+    \setshorttitle{Motion}
+    \RenewDocumentCommand \settitle { m } {
+        \tl_gset:Nn \g_dsek_title_tl {Motion #1 }
+        \section*{Motion:~ #1}
+    }
+}{
+    \setshorttitle{Proposition}
+    \RenewDocumentCommand \settitle { m } {
+        \tl_gset:Nn \g_dsek_title_tl {Proposition #1 }
+        \section*{Proposition:~ #1}
+    }
+}
+
+\NewDocumentCommand \setdemand { m } {
+    \tl_set:Nn \g_demand_tl { #1 }
+}
+
+\NewDocumentCommand \usedemand {} {
+    \vspace{0.5cm}
+    \tl_use:N \g_demand_tl
+}
+
+%% Handy commands to be used in att-lists
+\NewDocumentCommand \att { m } {
+  \item #1
+}
+\NewDocumentCommand \attdesc { m m } {
+    \item #1 \begin{description} \item #2 \end{description}
+}
+
+\ExplSyntaxOff
+

--- a/motionExample.tex
+++ b/motionExample.tex
@@ -1,0 +1,40 @@
+% use if creating a proposition
+% \documentclass[proposition]{dsekmotion}
+
+% or use this if creating a motion
+% \documentclass[motion]{dsekmotion}
+
+% or leave blank to default to motion
+\documentclass{dsekmotion}
+
+\usepackage{dsek}
+\begin{document}
+\settitle{Världens bästa förslag}
+\setauthor{Alfred Grip}
+\setdate{\today}
+\setmeeting{HTM2}
+
+% A demand should be included to let people know what you want demand
+\setdemand{Undertecknad yrkar att sektionsmötet må besluta}
+
+% Write the body of the proposal here
+Jag tycker att D-sektionen är störst och bäst i Skåne.
+
+% Good practice to include before the attlist
+\usedemand
+
+% A proposal should always contain an 'attlist'
+\begin{attlist}
+    \item steka pannkakor,
+    \item D-sektionen är bäst!
+    \att {såhär kan man skriva också}
+    \attdesc {denna att-satsen är så knepig}{den behöver en förklaring}
+    \item råsa är en fin färg
+\end{attlist}
+
+% You should also include a signature
+\signature{För D-sektionen}{Alfred Grip}{\LaTeX -fantast}
+% Hack to get same sign message for all signatures
+\signature{\phantom{}}{VA. Kant}{Okänd}
+
+\end{document}

--- a/motionExample.tex
+++ b/motionExample.tex
@@ -14,14 +14,11 @@
 \setdate{\today}
 \setmeeting{HTM2}
 
-% A demand should be included to let people know what you want demand
-\setdemand{Undertecknad yrkar att sektionsmötet må besluta}
-
 % Write the body of the proposal here
 Jag tycker att D-sektionen är störst och bäst i Skåne.
 
-% Good practice to include before the attlist
-\usedemand
+% Good practice to include a demand before the attlist
+Undertecknad yrkar att sektionsmötet må besluta
 
 % A proposal should always contain an 'attlist'
 \begin{attlist}


### PR DESCRIPTION
This is a proposal for a document class for "motion". Since a "proposition" is basically the same (just other another title) the document class takes in it as an option, but defaults to motion.

Feel free to make changes both to the structure and/or nameings. I thought of naming the class `dsekproposal`, since this has the option to be either a "motion" or a "proposition", and making two different document classes for the options seemed unnecessary. I like the name `dsekmotion` though since its very self-explaining.

Of course the documentations would have to be updated for this as well, maybe something you can do @fnurkla?

I also included an example of how this document class can be used.