### PR TITLE
Lägg till dokumentklass för Valberedningens förslag

### DIFF
--- a/dsekelectionproposal.cls
+++ b/dsekelectionproposal.cls
@@ -1,0 +1,64 @@
+\NeedsTeXFormat{LaTeX2e}
+
+\ProvidesClass{dsekelectionproposal}
+
+\RequirePackage{expl3}
+\RequirePackage{multicol}
+
+\DeclareOption*{\PassOptionsToClass{\CurrentOption}{dsekdoc}}
+
+\ProcessOptions \relax
+
+\LoadClass{dsekdoc}
+
+\ExplSyntaxOn
+
+\setshorttitle{Valberedningens~förslag}
+
+\NewDocumentEnvironment{vemsection}{ } {
+  \section*{Valberedningens~förslag~inför~\usemeeting}
+  Valberedningens~förslag~inför~\usemeeting\phantom{}~är~följande:
+  \begin{multicols}{2}
+    } {
+  \end{multicols}
+  \vspace{\baselineskip}
+}
+\NewDocumentCommand \getenumcount { m } {
+  \getrefnumber{#1}
+}
+\NewDocumentEnvironment{vemlist}{ m } {
+  \begin{minipage}{\columnwidth}
+    \ifnum\getenumcount{#1}>3 {
+    \textbf{#1}~(\,\getenumcount{#1}~st\,)
+    }\else {
+      \textbf{#1}
+    }
+    \fi
+    \vspace{-0.5em}
+    \begin{enumerate}[label=\textbullet]
+      \setlength\itemsep{-0.25em}
+      } {
+      \edef\@currentlabel{\arabic{\@enumctr}}\label{#1}
+    \end{enumerate}
+  \end{minipage}
+}
+
+\NewDocumentEnvironment{statistikpage}{ } {
+  \newpage
+  \section*{Valstatistik}
+  Nedan~presenteras~antalet~personer~som~genomgick~valprocessen~i~intervall~om~storlek~fem.
+  \vspace{\baselineskip}
+  \begin{multicols}{2}
+    } {
+  \end{multicols}
+}
+
+\NewDocumentCommand \statistik { m m } {
+  \begin{minipage}{\columnwidth}
+    \textbf{#1:}~#2~st
+    \vspace{\baselineskip}
+  \end{minipage}
+}
+
+\ExplSyntaxOff
+

--- a/examples/electionproposal-example.tex
+++ b/examples/electionproposal-example.tex
@@ -1,0 +1,71 @@
+\documentclass{dsekelectionproposal}
+\usepackage{dsek}
+\begin{document}
+\setauthor{Alfred Grip}
+\setdate{\today}
+\setmeeting{HTM-val}
+
+\begin{vemsection}
+
+    \begin{vemlist}{Post 1}
+        \item Donald Knuth
+        \item Ada Lovelace
+        \item Alan Turing
+        \item Grace Hopper
+        \item Linus Torvalds
+        \item Dennis Ritchie
+        \item Ken Thompson
+        \item Bjarne Stroustrup
+    \end{vemlist}
+
+    \begin{vemlist}{Post 2}
+        \item Donald Knuth
+        \item Ada Lovelace
+        \item Alan Turing
+        \item Grace Hopper
+    \end{vemlist}
+
+    \begin{vemlist}{Post 3}
+        \item Donald Knuth
+        \item Ada Lovelace
+        \item Alan Turing
+        \item Grace Hopper
+        \item Linus Torvalds
+        \item Dennis Ritchie
+    \end{vemlist}
+
+    \begin{vemlist}{Post 4}
+        \item Donald Knuth
+        \item Ada Lovelace
+        \item Alan Turing
+        \item Grace Hopper
+        \item Linus Torvalds
+        \item Dennis Ritchie
+        \item Ken Thompson
+        \item Bjarne Stroustrup
+        \item Guido van Rossum
+        \item Haskell Curry
+        \item John McCarthy
+        \item Edsger Dijkstra
+    \end{vemlist}
+
+    \begin{vemlist}{Post 5}
+        \item Råsa Pantern
+    \end{vemlist}
+
+\end{vemsection}
+
+\signature{För Valberedningen}{ValleB}{Valberedningens Ordförande}
+
+\begin{statistikpage}
+
+    \statistik{Post 1}{101-105}
+    \statistik{Post 2}{16-20}
+    \statistik{Post 3}{0-4}
+    \statistik{Post 4}{5-10}
+    \statistik{Post 5}{0-4}
+
+\end{statistikpage}
+
+
+\end{document}


### PR DESCRIPTION
Denna PR lägger till en dokumentklass för "Valberedningens förslag"-handlingar, och även ett exempel. Feel free att komma med åsikter på namngivning och annat strukturellt, i och med att dokumentklassen är ganska strikt och mycket är hårdkodat.