### PR TITLE
Tre att-listsändringar

### DIFF
--- a/dsek.sty
+++ b/dsek.sty
@@ -134,6 +134,15 @@
   \end{boldlist}
 }
 
+%% Handy commands to be used in att-lists
+\NewDocumentCommand \att { m } {
+  \item #1
+}
+
+\NewDocumentCommand \attdesc { m m } {
+  \item #1 \begin{description} \item #2 \end{description}
+}
+
 %% Signatures
 
 \dim_new:N \g_dsek_sign_space_height

--- a/dsek.sty
+++ b/dsek.sty
@@ -140,7 +140,7 @@
 }
 
 \NewDocumentCommand \attdesc { m m } {
-  \item #1 \begin{description} \item #2 \end{description}
+  \item #1 \begin{description} \item \textit{#2} \end{description}
 }
 
 %% Signatures

--- a/dsek.sty
+++ b/dsek.sty
@@ -10,6 +10,7 @@
 \RequirePackage{xparse}
 \RequirePackage{graphicx}
 \RequirePackage{enumitem}
+\RequirePackage{xcolor}
 
 \str_new:N \g_dsek_image_dir_str
 \str_gset:Nn \g_dsek_image_dir_str { images/ }
@@ -116,7 +117,7 @@
 \tl_new:N \g_dsek_att_list_format_tl
 \tl_set:Nn \g_dsek_att_list_format_tl
    {\stepcounter{DsekAttListItem}
-    {\footnotesize (\arabic{DsekAttListItem})}~\textbf{att}}
+    {\footnotesize {\color{gray}\arabic{DsekAttListItem}}}~\textbf{att}}
 
 \NewDocumentEnvironment{attlist}{} {
   \setcounter{DsekAttListItem}{0}

--- a/dsekmotion.cls
+++ b/dsekmotion.cls
@@ -27,12 +27,4 @@
   }
 }
 
-%% Handy commands to be used in att-lists
-\NewDocumentCommand \att { m } {
-  \item #1
-}
-\NewDocumentCommand \attdesc { m m } {
-  \item #1 \begin{description} \item #2 \end{description}
-}
-
 \ExplSyntaxOff


### PR DESCRIPTION
Här är några ändringar till att-listor som jag tror är bra. 

Den första är att ändra stilen på numreringen på att-satserna så att de är gråa istället för inom parenteser:
![image](https://github.com/Dsek-LTH/dsekdocs/assets/97372888/64eaacd1-f950-4365-ac44-de082e0ed2c2)
Detta är lite mer stilrent i mina ögon och så minskar det problemet med att numreringen sticker ut åt vänster (se #14). Problemet kvarstår när man når tvåsiffriga att-satser:
![image](https://github.com/Dsek-LTH/dsekdocs/assets/97372888/d7d53a5f-71cf-46f0-a99e-b305127f3a6c)

Nästa ändring är att flytta hjälpkommandona från `dsekmotion.cls` till `dsek.sty` så att de kan användas överallt att-listor används. 

Sista ändringen är att göra förklaringstexten i `\attdesc` kursiv så att man lätt kan urskilja den från själva att-satsen.