### PR TITLE
Gör typsnittet för titlar större

### DIFF
--- a/dsekdoc.cls
+++ b/dsekdoc.cls
@@ -17,9 +17,9 @@
 \DeclareOption*{\PassOptionsToClass{\CurrentOption}{article}}
 
 \bool_new:N \g_dsekdoc_shadow_maketitle_bool
-\bool_set_true:N \g_dsek_shadow_maketitle_bool
+\bool_set_false:N \g_dsek_shadow_maketitle_bool
 
-\DeclareOption{maketitle}{\bool_set_false:N \g_dsek_in_color_bool}
+\DeclareOption{titlecoverpage}{\bool_set_true:N \g_dsek_shadow_maketitle_bool}
 
 \ExplSyntaxOff
 
@@ -79,7 +79,6 @@
 \titleformat*{\section}{\Large\sffamily\bfseries}
 \titleformat*{\subsection}{\large\sffamily\bfseries}
 \titleformat*{\subsubsection}{\sffamily\bfseries}
-
 
 %% Paragraph styling
 \titleformat*{\paragraph}{\sffamily\bfseries}
@@ -164,6 +163,13 @@
 
 \NewDocumentCommand \usecovptext {} {
   \tl_use:N \g_dsek_covp_text_tl
+}
+
+%% Title formatting
+
+\RenewDocumentCommand \maketitle {} {
+  {\LARGE\sffamily\bfseries \usetitle{}}
+  \vspace{0.75em}
 }
 
 %% Cover page

--- a/dsekdocs.tex
+++ b/dsekdocs.tex
@@ -194,10 +194,11 @@ documents for which the standard style is desired.  It is based of the
 and footers amongst a few other things.
 
 \subsection{Options}
-The \textsf{dsekdoc} document declares two special options:
+The \textsf{dsekdoc} document class takes two special options:
 \begin{description}
-  \item[\texttt{maketitle}] makes \textsf{dsekdoc} not redefine the \cs{maketitle}
-        command (use the \cs{coverpage} command instead).
+  \item[\texttt{titlecoverpage}] makes \textsf{dsekdoc} redefine the
+        \cs{maketitle} command to insert the cover page (like \cs{coverpage}
+        always does).
   \item[\texttt{english}] tells the language package \textsf{polyglossia} that
         the main language for the document is English instead of Swedish.
 \end{description}
@@ -228,8 +229,11 @@ For longer, more important documents it is nice to have a cover page for the
 document.  By default, the cover page is inserted with
 
 \begin{center}
-  \cs{maketitle} or \cs{coverpage}
+  \cs{coverpage}
 \end{center}
+
+By giving the \texttt{titlecoverpage} to the document class, it can also be
+inserted with \cs{maketitle}.
 
 In addition to the guild's name, the guild's sigil and the title of the
 document, the cover page also features a small text that might be used as a

--- a/dsekmotion.cls
+++ b/dsekmotion.cls
@@ -18,14 +18,12 @@
 \bool_if:NTF \g_dsek_motion_bool {
   \setshorttitle{Motion}
   \RenewDocumentCommand \settitle { m } {
-    \tl_gset:Nn \g_dsek_title_tl {Motion #1 }
-    \section*{Motion:~ #1}
+    \tl_gset:Nn \g_dsek_title_tl {Motion:~#1 }
   }
 }{
   \setshorttitle{Proposition}
   \RenewDocumentCommand \settitle { m } {
-    \tl_gset:Nn \g_dsek_title_tl {Proposition #1 }
-    \section*{Proposition:~ #1}
+    \tl_gset:Nn \g_dsek_title_tl {Proposition:~#1 }
   }
 }
 


### PR DESCRIPTION
Den huvudsakliga förändringen här är att typsnittet för titlar är större för att motverka problemen beskrivna i #21. Här är en jämförelse med `\section*` som vi använde innan: 
![image](https://github.com/Dsek-LTH/dsekdocs/assets/97372888/5bfcc5be-df97-4845-83c9-8a36aff1bcab)

Vanligtvis ser det nog ut mer så här: 
![image](https://github.com/Dsek-LTH/dsekdocs/assets/97372888/d7fe6d17-24a7-42b9-9bc1-e25e660a1582)

Resterande ändringar är till för att uppmana folk till att faktiskt använda `\maketitle`. 