### PR TITLE
Ändringar till `Election proposal`

### DIFF
--- a/.latexmkrc
+++ b/.latexmkrc
@@ -1,0 +1,2 @@
+$pdf_mode = 1;
+$pdflatex = 'lualatex -interaction=nonstopmode';

--- a/dsekelectionproposal.cls
+++ b/dsekelectionproposal.cls
@@ -13,13 +13,11 @@
 
 \ExplSyntaxOn
 
-\setshorttitle{Valberedningens~förslag}
+\setshorttitle{Valförslag}
 
 \NewDocumentEnvironment{vemsection}{ } {
-  \section*{Valberedningens~förslag~inför~\usemeeting}
-  Valberedningens~förslag~inför~\usemeeting{}~är~följande:
   \begin{multicols}{2}
-} {
+    } {
   \end{multicols}
   \vspace{\baselineskip}
 }
@@ -29,7 +27,7 @@
 \NewDocumentEnvironment{vemlist}{ m } {
   \begin{minipage}{\columnwidth}
     \ifnum\getenumcount{#1}>3 {
-      \textbf{#1}~(\,\getenumcount{#1}~st\,)
+    \textbf{#1}~(\,\getenumcount{#1}~st\,)
     } \else {
       \textbf{#1}
     }
@@ -37,7 +35,7 @@
     \vspace{-0.5em}
     \begin{enumerate}[label=\textbullet]
       \setlength\itemsep{-0.25em}
-} {
+      } {
       \edef\@currentlabel{\arabic{\@enumctr}}\label{#1}
     \end{enumerate}
   \end{minipage}
@@ -50,7 +48,7 @@
   storlek~fem.
   \vspace{\baselineskip}
   \begin{multicols}{2}
-} {
+    } {
   \end{multicols}
 }
 

--- a/examples/electionproposal-example.tex
+++ b/examples/electionproposal-example.tex
@@ -1,12 +1,16 @@
 \documentclass{dsekelectionproposal}
 \usepackage{dsek}
+\usepackage[useregional,showdow]{datetime2}
 \begin{document}
 \setauthor{Alfred Grip}
 \setdate{\today}
 \setmeeting{HTM-val}
+\settitle{Valberedningens förslag inför HTM-val}
+% \settitle{Pepparvalberedningens förslag till Peppare}
+
+\maketitle
 
 \begin{vemsection}
-
     \begin{vemlist}{Post 1}
         \item Donald Knuth
         \item Ada Lovelace
@@ -55,7 +59,7 @@
 
 \end{vemsection}
 
-\signature{För Valberedningen}{ValleB}{Valberedningens Ordförande}
+\signature{För Valberedningen, dag som ovan}{ValleB}{Valberedningens ordförande}
 
 \begin{statistikpage}
 
@@ -67,5 +71,6 @@
 
 \end{statistikpage}
 
+% Totalt antal sökande: 126
 
 \end{document}

--- a/examples/motion-example.tex
+++ b/examples/motion-example.tex
@@ -14,6 +14,8 @@
 \setdate{\today}
 \setmeeting{HTM2}
 
+\maketitle
+
 % Write the body of the proposal here
 Jag tycker att D-sektionen är störst och bäst i Skåne.
 

--- a/examples/notice-example.tex
+++ b/examples/notice-example.tex
@@ -3,19 +3,19 @@
 
 \begin{document}
 \setmeeting{VTM1}
-\settitle{Kallelse}
+\settitle{Kallelse till sektionsmöte \usemeeting}
 \setauthor{V.A. Kant}
 \setdate{\today}
 
-\section*{Kallelse till sektionsmöte \usemeeting}
-\subsection*{Tid och plats}
+\maketitle
+\section*{Tid och plats}
 \textbf{Tid:} onsdag 30 februari klockan 12:15.
 
 \textbf{Plats:} E:A
 
 \textbf{Ajourneringsdag:} torsdag 31 februari klockan 17:15.
 
-\subsection*{Föredragningslista}
+\section*{Föredragningslista}
 \begin{agenda}
     \issue{OFMÖ}
     \issue{Val av mötesdryck}[Beslut]


### PR DESCRIPTION
Eftersom folk, inte endast valberedningen, använder sig av val-handlingar så känns det rimligt att lossa på dokumentklassen och låta folk styra själva vilken titel som används. För att återspegla detta så byter detta `shortName` också till "Valförslag" för att inkludera båda.

Lägger även in en `.latexmkrc` för smidighet.

Fixar även vissa exempel som missades när `\maketitle` introducerades.