### PR TITLE
Smarare att-listor

### DIFF
--- a/dsek.sty
+++ b/dsek.sty
@@ -112,26 +112,48 @@
   \end{itemize}
 }
 
+%%% Att lists
+
 \newcounter{DsekAttListItem}
 
-\tl_new:N \g_dsek_att_list_format_tl
-\tl_set:Nn \g_dsek_att_list_format_tl
+\tl_const:Nn \c_dsek_att_list_enumerated_format_tl
    {\stepcounter{DsekAttListItem}
-    {\footnotesize {\color{gray}\arabic{DsekAttListItem}}}~\textbf{att}}
+     {\footnotesize {\color{gray}\arabic{DsekAttListItem}}}~\textbf{att}}
 
-\NewDocumentEnvironment{attlist}{} {
+\tl_const:Nn \c_dsek_att_list_plain_format_tl {\textbf{att}}
+
+\bool_new:N \l__dsek_enumerate_bool
+\tl_new:N \l__dsek_att_list_format_tl
+
+\NewDocumentEnvironment{attlist}{ o } {
   \setcounter{DsekAttListItem}{0}
 
-  \begin{itemize}[label={\tl_use:N \g_dsek_att_list_format_tl},
+  \group_begin:
+  \bool_set_true:N \l__dsek_enumerate_bool
+
+  \keys_define:nn { dsek / attlist } { % Declare option keys
+    num .bool_set:N = \l__dsek_enumerate_bool,
+    num .default:n = {true},
+
+    nonum .bool_set_inverse:N = \l__dsek_enumerate_bool,
+    nonum .default:n = {true},
+  }
+
+  \IfValueT{#1} {\keys_set:nn { dsek / attlist } { #1 }} % Process them
+
+  \bool_if:NTF \l__dsek_enumerate_bool {
+    \tl_gset_eq:NN \l__dsek_att_list_format_tl
+                   \c_dsek_att_list_enumerated_format_tl
+  } {
+    \tl_gset_eq:NN \l__dsek_att_list_format_tl
+                   \c_dsek_att_list_plain_format_tl
+  }
+
+  \begin{itemize}[label={\tl_use:N \l__dsek_att_list_format_tl},
                   labelsep=.5em]
 } {
   \end{itemize}
-}
-
-\NewDocumentEnvironment{attlist*}{} { % Simpler version without numbering
-  \begin{boldlist}{att}
-} {
-  \end{boldlist}
+  \group_end:
 }
 
 %% Handy commands to be used in att-lists

--- a/dsek.sty
+++ b/dsek.sty
@@ -114,6 +114,9 @@
 
 %%% Att lists
 
+\newcounter{DsekAttList} % Number of att-lists
+\setcounter{DsekAttList}{0}
+
 \newcounter{DsekAttListItem}
 
 \tl_const:Nn \c_dsek_att_list_enumerated_format_tl
@@ -125,11 +128,24 @@
 \bool_new:N \l__dsek_enumerate_bool
 \tl_new:N \l__dsek_att_list_format_tl
 
+\NewDocumentCommand \attlistformat { } {
+  \tl_use:N \l__dsek_att_list_format_tl
+}
+
 \NewDocumentEnvironment{attlist}{ o } {
   \setcounter{DsekAttListItem}{0}
+  \stepcounter{DsekAttList}
 
   \group_begin:
-  \bool_set_true:N \l__dsek_enumerate_bool
+
+  % We use attlist:<num> labels to know the item count of attlists so that we
+  % can number them dynamically.  If there are more than 3 items we want to
+  % enumerate them.
+  \int_compare:nNnTF {\getrefnumber{attlist:\arabic{DsekAttList}}} > {3}{
+    \bool_set_true:N \l__dsek_enumerate_bool
+  } {
+    \bool_set_false:N \l__dsek_enumerate_bool
+  }
 
   \keys_define:nn { dsek / attlist } { % Declare option keys
     num .bool_set:N = \l__dsek_enumerate_bool,
@@ -139,7 +155,7 @@
     nonum .default:n = {true},
   }
 
-  \IfValueT{#1} {\keys_set:nn { dsek / attlist } { #1 }} % Process them
+  \IfValueT{#1} {\keys_set:nn { dsek / attlist } { #1 }} % Process keys
 
   \bool_if:NTF \l__dsek_enumerate_bool {
     \tl_gset_eq:NN \l__dsek_att_list_format_tl
@@ -149,10 +165,13 @@
                    \c_dsek_att_list_plain_format_tl
   }
 
-  \begin{itemize}[label={\tl_use:N \l__dsek_att_list_format_tl},
-                  labelsep=.5em]
+  \begin{enumerate}[label=\attlistformat,
+                    labelsep=.5em,]
+
 } {
-  \end{itemize}
+  \tl_set:Nx \@currentlabel { \arabic{\@enumctr} }
+  \label{attlist:\arabic{DsekAttList}}
+  \end{enumerate}
   \group_end:
 }
 


### PR DESCRIPTION
Än så länge lägger den här PR:en till några variabler som gör det lätt att bestämma när att-listor ska vara numrerade eller inte. Den lägger också till nycklar som kan skickas när man skapar en ny att-lista för att bestämma om den ska vara numrerad eller inte. Så nu kan man skriva
```latex
\begin{attlist}[nonum]
 \att inga
 \att nummer
 \att här
\end{attlist}
```
och slippa numrering.

Jag vill kunna göra så att den by default numrerar sig själv vid fyra eller fler items. Visst hade du något sånt @alfredgrip?