### PR TITLE
Implementera konsekvent datumhantering med `datetime2`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,15 @@ The package `dsek` depends on
 
 The document class `dsekdoc` depends on
 
-- dsek
-- fontspec†
-- polyglossia†
 - calc
+- dsek
+- datetime2
+- fontspec†
 - geometry
-- titlesec
 - hyperref
 - lastpage
+- polyglossia†
+- titlesec
 
 All document classes depend on `dsekdoc`, but some have additional dependencies:
 

--- a/dsekdoc.cls
+++ b/dsekdoc.cls
@@ -89,6 +89,19 @@
 \setlength{\parindent}{0mm}
 \setlength{\parskip}{3mm}
 
+%% Dates
+
+% This is done here to account for the langauge set in the last section
+\RequirePackage[useregional]{datetime2}
+
+%% Inserting dates
+
+\NewDocumentCommand \datum { s o m m } {
+  \IfValueF {#2} {\DTMlangsetup*{showyear=false}}
+  \IfValueTF {#2} {\DTMdate{#2-#3-#4}} {\DTMdate{1970-#3-#4}}
+  \IfValueF {#2} {\DTMlangsetup*{showyear=true}}
+}
+
 %% Document properties
 
 % Title

--- a/examples/minutes-example.tex
+++ b/examples/minutes-example.tex
@@ -11,8 +11,8 @@
 \documentclass{dsekminutes}
 
 % Set information about the meeting
-\setdate{20XX-03-28}
-\settitle{Protokoll Vårterminsmöte 20XX}
+\setdate{\datum[2069]{03}{28}}
+\settitle{Protokoll Vårterminsmöte 2069}
 \setmeeting{VTM}
 \setauthor{Fanny Adolvssson}
 

--- a/examples/notice-example.tex
+++ b/examples/notice-example.tex
@@ -9,11 +9,11 @@
 
 \maketitle
 \section*{Tid och plats}
-\textbf{Tid:} onsdag 30 februari klockan 12:15.
+\textbf{Tid:} onsdag \datum{2}{27} februari klockan 17:15.
 
 \textbf{Plats:} E:A
 
-\textbf{Ajourneringsdag:} torsdag 31 februari klockan 17:15.
+\textbf{Ajourneringsdag:} torsdag \datum{2}{28} februari klockan 17:15.
 
 \section*{Föredragningslista}
 \begin{agenda}


### PR DESCRIPTION
`\datum` och `\Datum` är kanske inte optimalt, men det krockar iaf inte med något. 

Se #13.